### PR TITLE
Botão "ENTRAR" corrigido

### DIFF
--- a/src/screens/login/Login.tsx
+++ b/src/screens/login/Login.tsx
@@ -38,6 +38,7 @@ export default function Login({ navigation }: { navigation: any }) {
         .catch((error) => {
           const errorMessage = error.message;
           alert(errorMessage)
+          setLoading(false);
         });
   };
 

--- a/src/screens/login/Signup.tsx
+++ b/src/screens/login/Signup.tsx
@@ -45,6 +45,7 @@ export default function Signup({ navigation }: { navigation: any }) {
       })
       .then(() => alert("Conta Criada com Sucesso 🎉"))
       .catch((error: any) => {
+        setLoading(false);
         alert(error.message);
       });
   };


### PR DESCRIPTION
Quando pressionado e a tentativa de login fosse falha, o botão ficava em estado de "ENTRANDO" infinito e não retornada ao estado normal após o erro ele volta ao estado "ENTRAR".